### PR TITLE
hotfix/removed-pytest-env-override

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,5 @@ testpaths =
     tests
 log_level = DEBUG
 log_format = %(asctime)s %(name)-12s %(funcName)-12s %(levelname)-8s %(message)s
-env_override_existing_values = 1
 env_files =
     tests/test.env


### PR DESCRIPTION
Remove pytest environment variables override flag. This was potentially causing build issues.